### PR TITLE
Type-level distinction between single-element wrapper and multi-element

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -18,13 +18,13 @@ to generate this file without the comments in this block.
   , "debug"
   , "effect"
   , "elmish"
-  , "exceptions"
   , "foldable-traversable"
   , "foreign"
   , "functions"
   , "prelude"
   , "psci-support"
   , "transformers"
+  , "unsafe-coerce"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -288,7 +288,7 @@ name :: EnzymeM SingleNode String
 name = E.name =<< ask
 
 -- | Returns the number of times a given selector appears.
-count :: String -> EnzymeM ManyNodes Int
+count :: forall n. String -> EnzymeM n Int
 count selector = E.count selector =<< ask
 
 -- | Updates the current element to reflect the latest state. Call this function

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -144,8 +144,8 @@ testElement element test = liftAff do
   runReaderT test wrapper
   E.unmount wrapper
 
--- | The current context can contain multiple DOM elements. This gets the
--- | element at the given index (zero-based). See
+-- | The current context can contain multiple DOM elements. This function
+-- | returns the element at the given index (zero-based). See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/at.html for more
 -- | info.
 -- |

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -114,6 +114,11 @@ import Elmish.Enzyme.Foreign as E
 import Foreign (Foreign)
 import Unsafe.Coerce (unsafeCoerce)
 
+-- | Monad for running Enzyme tests. Keeps a reference to the "current" DOM
+-- | element(s) and tracks the current element's multiplicity (whether it's a
+-- | single node or multiple) at type level (the `context` parameter), allowing
+-- | to check validity of certain functions at compile-time (e.g. `text` only
+-- | works on a single element).
 type EnzymeM (context :: NodeMultiplicity) = ReaderT (Wrapper context) Aff
 
 -- | Mounts the given component and runs the given action with the mounted

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -206,7 +206,7 @@ instance Find SingleNode where
 -- | some of the elements have the same parent. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for more
 -- | info.
-parent :: EnzymeM ManyNodes (Wrapper ManyNodes)
+parent :: forall n. EnzymeM n (Wrapper n)
 parent = E.parent =<< ask
 
 -- | Returns a `Boolean` indicating whether the current element matches

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -158,18 +158,18 @@ at index = E.at index =<< ask
 -- | Returns the string representing the DOM tree of the current element(s). See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/debug.html for more
 -- | info.
-debug :: forall ctx. DebugWarning => EnzymeM ctx String
+debug :: forall n. DebugWarning => EnzymeM n String
 debug = E.debug =<< ask
 
 -- | Logs a string representing the DOM tree of the current element(s).
-trace :: forall ctx. DebugWarning => EnzymeM ctx Unit
+trace :: forall n. DebugWarning => EnzymeM n Unit
 trace = log =<< debug
 
 -- | Returns a `Boolean` indicating whether a given selector exists within the
 -- | current element.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/exists.html
 -- | for more info.
-exists :: forall ctx. String -> EnzymeM ctx Boolean
+exists :: forall n. String -> EnzymeM n Boolean
 exists selector = E.exists selector =<< ask
 
 -- | Finds all elements matching the given selector within the current

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -41,7 +41,7 @@
 -- |      content `shouldEqual` "I'm the second button!"
 -- |```
 -- |
--- | Alternatively, operations that return an `Wrapper` may be combined
+-- | Alternatively, operations that return a `Wrapper` may be combined
 -- | in a chain using the `>>` operator (which is just a convenient facade for
 -- | `withElement` under the hood):
 -- |
@@ -295,7 +295,7 @@ count selector = E.count selector =<< ask
 update :: forall n. EnzymeM n Unit
 update = E.update =<< ask
 
--- | Takes an `Wrapper` and runs an `EnzymeM` computation with the given
+-- | Takes a `Wrapper` and runs an `EnzymeM` computation with the given
 -- | wrapper as the new implicit wrapper. This can be thought of as analogous to
 -- | Capybara’s `within`.
 -- |
@@ -311,7 +311,7 @@ withElement wrapper =
 
 -- | A version of `withElement` that takes the `Wrapper` wrapped in
 -- | `EnzymeM` rather than "naked". Aliased as the `>>` operator, this allows
--- | for handy chaining of operations that return an `Wrapper`, for
+-- | for handy chaining of operations that return a `Wrapper`, for
 -- | example:
 -- |
 -- | ```purescript

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -4,7 +4,7 @@
 -- |
 -- | The API here is presented in monadic style, with the idea that there is
 -- | always a "current" DOM element (or, more precisely, current
--- | `ElementWrapper`, which may refer to zero or more actual DOM elements),
+-- | `Wrapper`, which may refer to zero or more actual DOM elements),
 -- | with respect to which all operations run. A test starts with either
 -- | `testComponent` or `testElement`, and it's that component (or element) that
 -- | becomes the "current" element at the start, for example:
@@ -41,7 +41,7 @@
 -- |      content `shouldEqual` "I'm the second button!"
 -- |```
 -- |
--- | Alternatively, operations that return an `ElementWrapper` may be combined
+-- | Alternatively, operations that return an `Wrapper` may be combined
 -- | in a chain using the `>>` operator (which is just a convenient facade for
 -- | `withElement` under the hood):
 -- |
@@ -74,8 +74,7 @@ module Elmish.Enzyme
   , count
   , debug
   , exists
-  , find
-  , findSingle
+  , class Find, find
   , forEach
   , is
   , length
@@ -110,36 +109,37 @@ import Effect.Class.Console (log)
 import Effect.Exception (throw)
 import Elmish (ReactElement)
 import Elmish.Component (ComponentDef)
-import Foreign (Foreign)
-import Elmish.Enzyme.Foreign (ElementWrapper)
+import Elmish.Enzyme.Foreign (ManyNodes, NodeMultiplicity, SingleNode, Wrapper)
+import Elmish.Enzyme.Foreign (Wrapper, SingleNode, ManyNodes, configure) as ForeignExports
 import Elmish.Enzyme.Foreign as E
-import Elmish.Enzyme.Foreign (ElementWrapper, configure) as ForeignExports
+import Foreign (Foreign)
+import Unsafe.Coerce (unsafeCoerce)
 
--- | Monad for running Enzyme tests. Keeps a reference to the "current" DOM
--- | element(s).
-type EnzymeM = ReaderT ElementWrapper Aff
+type EnzymeM (context :: NodeMultiplicity) = ReaderT (Wrapper context) Aff
 
--- | Runs a test with a `ComponentDef` as the implicit `ElementWrapper`
+-- | Mounts the given component and runs the given action with the mounted
+-- | component as current context.
 -- |
 -- | ```purescript
 -- | it "displays content" do
 -- |   testComponent (MyComponent.def props) do
 -- |     exists ".t--my-content" >>= shouldEqual true
 -- | ```
-testComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> EnzymeM Unit -> m Unit
+testComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> EnzymeM SingleNode Unit -> m Unit
 testComponent component test = liftAff do
   wrapper <- E.mountComponent component
   runReaderT test wrapper
   E.unmount wrapper
 
--- | Runs a test with a `ReactElement` as the implicit `ElementWrapper`
+-- | Mounts the given element and runs the given action with the mounted element
+-- | as current context.
 -- |
 -- | ```purescript
 -- | pending' "displays content"
 -- |   testElement (MyElement.render props) do
 -- |     exists ".t--my-content" >>= shouldEqual true
 -- | ```
-testElement :: forall m. MonadAff m => ReactElement -> EnzymeM Unit -> m Unit
+testElement :: forall m. MonadAff m => ReactElement -> EnzymeM SingleNode Unit -> m Unit
 testElement element test = liftAff do
   wrapper <- E.mount element
   runReaderT test wrapper
@@ -153,59 +153,73 @@ testElement element test = liftAff do
 -- |```purs
 -- |find "button" >> at 3 >> text >>= shouldEqual "Fourth button"
 -- |```
-at :: Int -> EnzymeM ElementWrapper
+at :: Int -> EnzymeM ManyNodes (Wrapper SingleNode)
 at index = E.at index =<< ask
 
 -- | Returns the string representing the DOM tree of the current element(s). See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/debug.html for more
 -- | info.
-debug :: DebugWarning => EnzymeM String
+debug :: forall ctx. DebugWarning => EnzymeM ctx String
 debug = E.debug =<< ask
 
 -- | Logs a string representing the DOM tree of the current element(s).
-trace :: DebugWarning => EnzymeM Unit
+trace :: forall ctx. DebugWarning => EnzymeM ctx Unit
 trace = log =<< debug
 
 -- | Returns a `Boolean` indicating whether a given selector exists within the
 -- | current element.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/exists.html
 -- | for more info.
-exists :: String -> EnzymeM Boolean
+exists :: forall ctx. String -> EnzymeM ctx Boolean
 exists selector = E.exists selector =<< ask
 
--- | Finds all elements with the given selector within the current element. See
--- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for
--- | more info.
-find :: String -> EnzymeM ElementWrapper
-find selector = E.find selector =<< ask
+class Find (nResult :: NodeMultiplicity) where
+  -- | Finds all elements matching the given selector within the current
+  -- | context. If the surrounding code expects a single element (e.g. calling
+  -- | `text` or `prop`), but multiple (or zero) elements match the given
+  -- | selector, the `find` function will crash with an error message explaining
+  -- | that.
+  -- |
+  -- |```purs
+  -- |num <- find "p" >> count
+  -- |num `shouldEqual` 5   -- There are five <p> elements
+  -- |
+  -- |txt <- find "p" >> text   -- Crash: expected to find one element matching 'p', but found 5
+  -- |```
+  -- |
+  -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for
+  -- | more info.
+  find :: forall nOuter. String -> EnzymeM nOuter (Wrapper nResult)
 
--- | Returns parent of the current element. See
--- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for
--- | more info.
-parent :: EnzymeM ElementWrapper
+instance Find ManyNodes where
+  find selector = E.find selector =<< ask
+
+instance Find SingleNode where
+  find selector = do
+    all <- find selector
+    when (E.length all /= 1) $
+      liftEffect $ throw $ "Expected to find one element matching '" <> selector <> "', but found " <> show (E.length all)
+    pure $ unsafeCoerce all
+
+-- | Returns parent of the current element. When the current context contains
+-- | multiple elements, the result will contain exactly as many parents, even if
+-- | some of the elements have the same parent. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for more
+-- | info.
+parent :: EnzymeM ManyNodes (Wrapper ManyNodes)
 parent = E.parent =<< ask
-
--- | Finds a single element with the given selector within the current element
--- | (see also `find`). Crashes if no elements or more than one element was
--- | found.
-findSingle :: String -> EnzymeM ElementWrapper
-findSingle selector = do
-  e <- find selector
-  when (E.length e /= 1) $
-    liftEffect $ throw $ "Expected to find a single element '" <> selector <> "', but found " <> show (E.length e)
-  pure e
 
 -- | Returns a `Boolean` indicating whether the current element matches
 -- | the given selector.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/is.html
 -- | for more info.
-is :: String -> EnzymeM Boolean
+is :: String -> EnzymeM SingleNode Boolean
 is selector = E.is selector =<< ask
 
 -- | Returns the value of the current element’s prop with a certain key.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/prop.html
 -- | for more info.
-prop :: forall a. String -> EnzymeM a
+prop :: forall a. String -> EnzymeM SingleNode a
 prop key = E.prop key =<< ask
 
 -- | Sets the state of the current element. Note that this is
@@ -215,12 +229,12 @@ prop key = E.prop key =<< ask
 -- | NOTE: this is a type-unsafe operation. There is no check to make sure the
 -- | state being set here has the type of the actual state the component in
 -- | question is using.
-unsafeSetState :: forall state. state -> EnzymeM Unit
+unsafeSetState :: forall state. state -> EnzymeM SingleNode Unit
 unsafeSetState newState =
   E.unsafeSetState newState =<< ask
 
 -- | A convenience function for calling `simulate'` without an `event` arg.
-simulate :: String -> EnzymeM Unit
+simulate :: String -> EnzymeM SingleNode Unit
 simulate eventType =
   E.simulate eventType =<< ask
 
@@ -235,7 +249,7 @@ simulate eventType =
 -- |
 -- | NOTE 2: This function only works for native HTML elements. For emitting
 -- | events on custom React components, use `simulateCustom`.
-simulate' :: forall r. String -> Record r -> EnzymeM Unit
+simulate' :: forall r. String -> Record r -> EnzymeM SingleNode Unit
 simulate' eventType event =
   E.simulate' eventType event =<< ask
 
@@ -247,34 +261,34 @@ simulate' eventType event =
 -- | checks whatsoever. This is, of course, not type-safe, but it is in line
 -- | with what the event handler should expect anyway: after all, the underlying
 -- | JavaScript component may pass anything at all as event argument.
-simulateCustom' :: forall a. String -> a -> EnzymeM Unit
+simulateCustom' :: forall a. String -> a -> EnzymeM SingleNode Unit
 simulateCustom' eventType event =
   E.simulateCustom' eventType event =<< ask
 
 -- | A convienience shorthand for clicking an element known by CSS selector
-clickOn :: String -> EnzymeM Unit
+clickOn :: String -> EnzymeM ManyNodes Unit
 clickOn selector = find selector >> simulate "click"
 
 -- | Returns the state of the current element. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/state.html for more
 -- | info.
-state :: EnzymeM Foreign
+state :: EnzymeM SingleNode Foreign
 state = E.state =<< ask
 
 -- | Returns the text within the current element.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/text.html
 -- | for more info.
-text :: EnzymeM String
+text :: EnzymeM SingleNode String
 text = E.text =<< ask
 
 -- | Returns tag name of the current element.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/name.html
 -- | for more info.
-name :: EnzymeM String
+name :: EnzymeM SingleNode String
 name = E.name =<< ask
 
 -- | Returns the number of times a given selector appears.
-count :: String -> EnzymeM Int
+count :: String -> EnzymeM ManyNodes Int
 count selector = E.count selector =<< ask
 
 -- | Updates the current element to reflect the latest state. Call this function
@@ -285,10 +299,10 @@ count selector = E.count selector =<< ask
 -- |
 -- | NOTE: this only works on the "root" element, which means it cannot be
 -- | called inside `withSelector` or `withElement`.
-update :: EnzymeM Unit
+update :: forall n. EnzymeM n Unit
 update = E.update =<< ask
 
--- | Takes an `ElementWrapper` and runs an `EnzymeM` computation with the given
+-- | Takes an `Wrapper` and runs an `EnzymeM` computation with the given
 -- | wrapper as the new implicit wrapper. This can be thought of as analogous to
 -- | Capybara’s `within`.
 -- |
@@ -298,25 +312,25 @@ update = E.update =<< ask
 -- |   simulate "click"
 -- |   prop "disabled" >>= shouldEqual true
 -- | ```
-withElement :: forall a. ElementWrapper -> EnzymeM a -> EnzymeM a
+withElement :: forall a nOuter nInner. Wrapper nInner -> EnzymeM nInner a -> EnzymeM nOuter a
 withElement wrapper =
   withReaderT $ const wrapper
 
--- | A version of `withElement` that takes the `ElementWrapper` wrapped in
+-- | A version of `withElement` that takes the `Wrapper` wrapped in
 -- | `EnzymeM` rather than "naked". Aliased as the `>>` operator, this allows
--- | for handy chaining of operations that return an `ElementWrapper`, for
+-- | for handy chaining of operations that return an `Wrapper`, for
 -- | example:
 -- |
 -- | ```purescript
 -- | find ".foo" >> at 1 >> find ".bar" >> simulate "click"
 -- | ```
-withElementM :: forall a. EnzymeM ElementWrapper -> EnzymeM a -> EnzymeM a
+withElementM :: forall a nOuter nInner. EnzymeM nOuter (Wrapper nInner) -> EnzymeM nInner a -> EnzymeM nOuter a
 withElementM el f = el >>= \e -> withElement e f
 
 infixl 1 withElementM as >>
 
 -- | Basically, a DSL-friendly equivalent of `map`: for each element in the
--- | current `ElementWrapper` performs the given action and returns all results
+-- | current `Wrapper` performs the given action and returns all results
 -- | of that action as an array.
 -- |
 -- | Example:
@@ -324,15 +338,15 @@ infixl 1 withElementM as >>
 -- |     allNames <- find ".t--foo" >> mapEach text
 -- |     allValues <- find ".t--foo" >> mapEach (prop "value")
 -- |
-mapEach :: forall a. EnzymeM a -> EnzymeM (Array a)
+mapEach :: forall a. EnzymeM SingleNode a -> EnzymeM ManyNodes (Array a)
 mapEach f = toArray >>= traverse \e -> withElement e f
 
--- | Returns all elements contained in the current `ElementWrapper` as an array.
-toArray :: EnzymeM (Array ElementWrapper)
+-- | Returns all elements contained in the current `Wrapper` as an array.
+toArray :: EnzymeM ManyNodes (Array (Wrapper SingleNode))
 toArray = E.toArray =<< ask
 
 -- | Basically, a DSL-friendly equivalent of `for_`: for each element in the
--- | current `ElementWrapper` performs the given effect.
+-- | current `Wrapper` performs the given effect.
 -- |
 -- | Example:
 -- |
@@ -343,11 +357,11 @@ toArray = E.toArray =<< ask
 -- |       find "input[type=checkbox]" >> simulate "change"
 -- |       find ".t--bar" >> text >>= shouldEqual "qux"
 -- |
-forEach :: EnzymeM Unit -> EnzymeM Unit
+forEach :: EnzymeM SingleNode Unit -> EnzymeM ManyNodes Unit
 forEach f = E.forEach (\e -> withElement e f) =<< ask
 
 -- | Returns number of elements in the current context
-length :: EnzymeM Int
+length :: EnzymeM ManyNodes Int
 length = E.length <$> ask
 
 -- | A convenience function which finds an element for the given selector and
@@ -358,29 +372,29 @@ length = E.length <$> ask
 -- |   simulate "click"
 -- |   prop "disabled" >>= shouldEqual true
 -- | ```
-withSelector :: forall a. String -> EnzymeM a -> EnzymeM a
+withSelector :: forall a n. String -> EnzymeM SingleNode a -> EnzymeM n a
 withSelector selector m = do
-  wrapper <- findSingle selector
+  wrapper <- find selector
   withElement wrapper m
 
 -- | Performs active wait while the given condition is true. Times out with a
 -- | crash after a second.
-waitWhile :: EnzymeM Boolean -> EnzymeM Unit
+waitWhile :: forall n. EnzymeM n Boolean -> EnzymeM n Unit
 waitWhile = waitWhile' (Milliseconds 1000.0)
 
 -- | Performs active wait while the given condition is false. Times out with a
 -- | crash after a second.
-waitUntil :: EnzymeM Boolean -> EnzymeM Unit
+waitUntil :: forall n. EnzymeM n Boolean -> EnzymeM n Unit
 waitUntil = waitUntil' (Milliseconds 1000.0)
 
 -- | Performs active wait while the given condition is true. Times out with a
 -- | crash after given time period.
-waitWhile' :: Milliseconds -> EnzymeM Boolean -> EnzymeM Unit
+waitWhile' :: forall n. Milliseconds -> EnzymeM n Boolean -> EnzymeM n Unit
 waitWhile' timeout f = waitUntil' timeout $ not <$> f
 
 -- | Performs active wait while the given condition is true. Times out with a
 -- | crash after given time period.
-waitUntil' :: Milliseconds -> EnzymeM Boolean -> EnzymeM Unit
+waitUntil' :: forall n. Milliseconds -> EnzymeM n Boolean -> EnzymeM n Unit
 waitUntil' (Milliseconds timeout) f = go timeout
   where
     go remaining = do

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -266,7 +266,7 @@ simulateCustom' eventType event =
   E.simulateCustom' eventType event =<< ask
 
 -- | A convienience shorthand for clicking an element known by CSS selector
-clickOn :: String -> EnzymeM ManyNodes Unit
+clickOn :: forall n. String -> EnzymeM n Unit
 clickOn selector = find selector >> simulate "click"
 
 -- | Returns the state of the current element. See

--- a/src/Elmish/Enzyme/Foreign.js
+++ b/src/Elmish/Enzyme/Foreign.js
@@ -6,8 +6,6 @@ exports.configure_ = (adapter) => {
 
 exports.mount_ = Enzyme.mount
 
-exports.shallow_ = Enzyme.shallow
-
 exports.at_ = (index, wrapper) => wrapper.at(index)
 
 exports.debug_ = (wrapper) => wrapper.debug()

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -92,10 +92,10 @@ shallowComponent def = do
   liftAff $ delay (Milliseconds 0.0)
   pure wrapper
 
--- | A `Wrapper` can have multiple nodes. This gets the node at the
--- | given index.
--- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/at.html for
--- | more info.
+-- | A `Wrapper` can wrap multiple DOM nodes. This function returns the node at
+-- | the given index. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/at.html for more
+-- | info.
 at :: forall m. MonadEffect m => Int -> Wrapper ManyNodes -> m (Wrapper SingleNode)
 at idx w = liftEffect $ runEffectFn2 at_ idx w
 

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -213,7 +213,7 @@ name :: forall m. MonadEffect m => Wrapper SingleNode -> m String
 name = liftEffect <<< runEffectFn1 name_
 
 -- | Returns the number of times a given selector appears within a wrapper.
-count :: forall m. MonadEffect m => String -> Wrapper ManyNodes -> m Int
+count :: forall m n. MonadEffect m => String -> Wrapper n -> m Int
 count selector wrapper = do
   length <$> find selector wrapper
 

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -65,7 +65,7 @@ mount =
 
 -- | A convenience function for creating a full wrapper from a `ComponentDef`
 -- | rather than a `ReactElement`. This also adds a `delay (Milliseconds 0.0)`
--- | to allow any `Effect`s in `def.init` to run.
+-- | to allow any effects in `def.init` to run.
 mountComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m (Wrapper SingleNode)
 mountComponent def = do
   wrapper <- liftEffect $ mount =<< construct def
@@ -84,7 +84,7 @@ shallow =
 
 -- | A convenience function for creating a shallow wrapper from a `ComponentDef`
 -- | rather than a `ReactElement`. This also adds a `delay (Milliseconds 0.0)`
--- | to allow any `Effect`s in `def.init` to run.
+-- | to allow any effects in `def.init` to run.
 shallowComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m (Wrapper SingleNode)
 shallowComponent def = do
   wrapper <- liftEffect $ shallow $

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -8,8 +8,6 @@ module Elmish.Enzyme.Foreign
   , count
   , mount
   , mountComponent
-  , shallow
-  , shallowComponent
   , at
   , debug
   , exists
@@ -43,7 +41,6 @@ import Effect.Aff.Compat (EffectFn2, EffectFn3, EffectFnAff, fromEffectFnAff, ru
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Uncurried (EffectFn1, runEffectFn1)
 import Elmish (ComponentDef, ReactElement, construct)
-import Elmish.Component (ComponentName(..), wrapWithLocalState)
 import Elmish.Enzyme.Adapter (Adapter)
 import Foreign (Foreign, unsafeToForeign)
 
@@ -71,25 +68,6 @@ mountComponent def = do
   wrapper <- liftEffect $ mount =<< construct def
   liftAff $ delay (Milliseconds 0.0)
   update wrapper
-  pure wrapper
-
--- | Creates a “shallow wrapper” around an element, which basically means the
--- | DOM tree is rendered up to the next layer of React components. So all plain
--- | HTML within the given `ReactElement` is rendered, but not HTML within
--- | nested components. This does not cause a headless browser to spin up.
--- | See https://enzymejs.github.io/enzyme/docs/api/shallow.html for more info.
-shallow :: forall m. MonadEffect m => ReactElement -> m (Wrapper SingleNode)
-shallow =
-  liftEffect <<< runEffectFn1 shallow_
-
--- | A convenience function for creating a shallow wrapper from a `ComponentDef`
--- | rather than a `ReactElement`. This also adds a `delay (Milliseconds 0.0)`
--- | to allow any effects in `def.init` to run.
-shallowComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m (Wrapper SingleNode)
-shallowComponent def = do
-  wrapper <- liftEffect $ shallow $
-    wrapWithLocalState (ComponentName "Shallow Test Component") (const def) {}
-  liftAff $ delay (Milliseconds 0.0)
   pure wrapper
 
 -- | A `Wrapper` can wrap multiple DOM nodes. This function returns the node at
@@ -236,8 +214,6 @@ update = liftEffect <<< runEffectFn1 update_
 foreign import configure_ :: EffectFn1 Adapter Unit
 
 foreign import mount_ :: EffectFn1 ReactElement (Wrapper SingleNode)
-
-foreign import shallow_ :: EffectFn1 ReactElement (Wrapper SingleNode)
 
 foreign import at_ :: EffectFn2 Int (Wrapper ManyNodes) (Wrapper SingleNode)
 

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -57,7 +57,7 @@ data Wrapper (w :: NodeMultiplicity)
 configure :: Adapter -> Effect Unit
 configure = runEffectFn1 configure_
 
--- | Fully mounts a `ReactElement` and returns an `Wrapper`.
+-- | Fully mounts a `ReactElement` and returns a `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/shallow.html for more info.
 mount :: forall m. MonadEffect m => ReactElement -> m (Wrapper SingleNode)
 mount =
@@ -92,7 +92,7 @@ shallowComponent def = do
   liftAff $ delay (Milliseconds 0.0)
   pure wrapper
 
--- | An `Wrapper` can have multiple nodes. This gets the node at the
+-- | A `Wrapper` can have multiple nodes. This gets the node at the
 -- | given index.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/at.html for
 -- | more info.
@@ -144,7 +144,7 @@ is selector w = liftEffect $ runEffectFn2 is_ selector w
 -- | Returns number of elements in a given wrapper
 foreign import length :: Wrapper ManyNodes -> Int
 
--- | Returns the value of an `Wrapper`’s prop with a certain key.
+-- | Returns the value of a `Wrapper`’s prop with a certain key.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/prop.html
 -- | for more info.
 prop :: forall a m. MonadEffect m => String -> Wrapper SingleNode -> m a

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -3,7 +3,7 @@
 -- | wrapper around Enzyme with a few convenience functions added. For a
 -- | convenient API, use `Elmish.Enzyme` instead.
 module Elmish.Enzyme.Foreign
-  ( ElementWrapper
+  ( Wrapper, NodeMultiplicity, SingleNode, ManyNodes
   , configure
   , count
   , mount
@@ -47,20 +47,26 @@ import Elmish.Component (ComponentName(..), wrapWithLocalState)
 import Elmish.Enzyme.Adapter (Adapter)
 import Foreign (Foreign, unsafeToForeign)
 
+data NodeMultiplicity
+foreign import data SingleNode :: NodeMultiplicity
+foreign import data ManyNodes :: NodeMultiplicity
+
+data Wrapper (w :: NodeMultiplicity)
+
 -- | Configures the correct Enzyme adapter. Called once in the main spec.
 configure :: Adapter -> Effect Unit
 configure = runEffectFn1 configure_
 
--- | Fully mounts a `ReactElement` and returns an `ElementWrapper`.
+-- | Fully mounts a `ReactElement` and returns an `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/shallow.html for more info.
-mount :: forall m. MonadEffect m => ReactElement -> m ElementWrapper
+mount :: forall m. MonadEffect m => ReactElement -> m (Wrapper SingleNode)
 mount =
   liftEffect <<< runEffectFn1 mount_
 
 -- | A convenience function for creating a full wrapper from a `ComponentDef`
 -- | rather than a `ReactElement`. This also adds a `delay (Milliseconds 0.0)`
 -- | to allow any `Effect`s in `def.init` to run.
-mountComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m ElementWrapper
+mountComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m (Wrapper SingleNode)
 mountComponent def = do
   wrapper <- liftEffect $ mount =<< construct def
   liftAff $ delay (Milliseconds 0.0)
@@ -72,79 +78,79 @@ mountComponent def = do
 -- | HTML within the given `ReactElement` is rendered, but not HTML within
 -- | nested components. This does not cause a headless browser to spin up.
 -- | See https://enzymejs.github.io/enzyme/docs/api/shallow.html for more info.
-shallow :: forall m. MonadEffect m => ReactElement -> m ElementWrapper
+shallow :: forall m. MonadEffect m => ReactElement -> m (Wrapper SingleNode)
 shallow =
   liftEffect <<< runEffectFn1 shallow_
 
 -- | A convenience function for creating a shallow wrapper from a `ComponentDef`
 -- | rather than a `ReactElement`. This also adds a `delay (Milliseconds 0.0)`
 -- | to allow any `Effect`s in `def.init` to run.
-shallowComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m ElementWrapper
+shallowComponent :: forall m msg state. MonadAff m => ComponentDef msg state -> m (Wrapper SingleNode)
 shallowComponent def = do
   wrapper <- liftEffect $ shallow $
     wrapWithLocalState (ComponentName "Shallow Test Component") (const def) {}
   liftAff $ delay (Milliseconds 0.0)
   pure wrapper
 
--- | An `ElementWrapper` can have multiple nodes. This gets the node at the
+-- | An `Wrapper` can have multiple nodes. This gets the node at the
 -- | given index.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/at.html for
 -- | more info.
-at :: forall m. MonadEffect m => Int -> ElementWrapper -> m ElementWrapper
+at :: forall m. MonadEffect m => Int -> Wrapper ManyNodes -> m (Wrapper SingleNode)
 at idx w = liftEffect $ runEffectFn2 at_ idx w
 
--- | Returns all elements contained in the given `ElementWrapper` as an array.
-toArray :: forall m. MonadEffect m => ElementWrapper -> m (Array ElementWrapper)
+-- | Returns all elements contained in the given `Wrapper` as an array.
+toArray :: forall m. MonadEffect m => Wrapper ManyNodes -> m (Array (Wrapper SingleNode))
 toArray e = for (0 .. (length e - 1)) \idx -> at idx e
 
 -- | Runs the given action for every element contained in the given
--- | `ElementWrapper` as an array.
-forEach :: forall m. MonadEffect m => (ElementWrapper -> m Unit) -> ElementWrapper -> m Unit
+-- | `Wrapper` as an array.
+forEach :: forall m. MonadEffect m => (Wrapper SingleNode -> m Unit) -> Wrapper ManyNodes -> m Unit
 forEach f e = for_ (0 .. (length e - 1)) \idx -> at idx e >>= f
 
 -- | Prints the shallow DOM tree up to any nested React components.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/debug.html
 -- | for more info.
-debug :: forall m. MonadEffect m => ElementWrapper -> m String
+debug :: forall m n. MonadEffect m => Wrapper n -> m String
 debug = liftEffect <<< runEffectFn1 debug_
 
 -- | Returns a `Boolean` indicating whether a given selector exists within the
--- | given `ElementWrapper`.
+-- | given `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/exists.html
 -- | for more info.
-exists :: forall m. MonadEffect m => String -> ElementWrapper -> m Boolean
+exists :: forall m n. MonadEffect m => String -> Wrapper n -> m Boolean
 exists selector w = liftEffect $ runEffectFn2 exists_ selector w
 
 -- | Finds all elements with the given selector within the given
--- | `ElementWrapper`. See
+-- | `Wrapper`. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/find.html for
 -- | more info.
-find :: forall m. MonadEffect m => String -> ElementWrapper -> m ElementWrapper
+find :: forall m n. MonadEffect m => String -> Wrapper n -> m (Wrapper ManyNodes)
 find selector w = liftEffect $ runEffectFn2 find_ selector w
 
--- | Returns parent of the given `ElementWrapper`. See
+-- | Returns parent of the given `Wrapper`. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/parent.html for
 -- | more info.
-parent :: forall m. MonadEffect m => ElementWrapper -> m ElementWrapper
+parent :: forall m n. MonadEffect m => Wrapper n -> m (Wrapper n)
 parent w = liftEffect $ runEffectFn1 parent_ w
 
--- | Returns a `Boolean` indicating whether the given `ElementWrapper` matches
+-- | Returns a `Boolean` indicating whether the given `Wrapper` matches
 -- | the given selector.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/is.html
 -- | for more info.
-is :: forall m. MonadEffect m => String -> ElementWrapper -> m Boolean
+is :: forall m. MonadEffect m => String -> (Wrapper SingleNode) -> m Boolean
 is selector w = liftEffect $ runEffectFn2 is_ selector w
 
 -- | Returns number of elements in a given wrapper
-foreign import length :: ElementWrapper -> Int
+foreign import length :: Wrapper ManyNodes -> Int
 
--- | Returns the value of an `ElementWrapper`’s prop with a certain key.
+-- | Returns the value of an `Wrapper`’s prop with a certain key.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/prop.html
 -- | for more info.
-prop :: forall a m. MonadEffect m => String -> ElementWrapper -> m a
+prop :: forall a m. MonadEffect m => String -> Wrapper SingleNode -> m a
 prop selector w = liftEffect $ runEffectFn2 prop_ selector w
 
--- | Sets the state of the given `ElementWrapper`. This is asynchronous, so runs
+-- | Sets the state of the given `Wrapper`. This is asynchronous, so runs
 -- | in a `MonadAff`. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/setState.html for
 -- | more info.
@@ -152,16 +158,16 @@ prop selector w = liftEffect $ runEffectFn2 prop_ selector w
 -- | NOTE: this is a type-unsafe operation. There is no check to make sure the
 -- | state being set here has the type of the actual state the component in
 -- | question is using.
-unsafeSetState :: forall state m. MonadAff m => state -> ElementWrapper -> m Unit
+unsafeSetState :: forall state m. MonadAff m => state -> Wrapper SingleNode -> m Unit
 unsafeSetState newState =
   liftAff <<< fromEffectFnAff <<< runFn2 unsafeSetState_ newState
 
 -- | A convenience function for calling `simulate'` without an `event` arg.
-simulate :: forall m. MonadEffect m => String -> ElementWrapper -> m Unit
+simulate :: forall m. MonadEffect m => String -> Wrapper SingleNode -> m Unit
 simulate eventType =
   simulate' eventType {}
 
--- | Simulates a certain event type on a given `ElementWrapper`. The event argument
+-- | Simulates a certain event type on a given `Wrapper`. The event argument
 -- | is a record that gets merged with a simulated React synthetic event before
 -- | being passed to the component’s event handler. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/simulate.html for
@@ -172,7 +178,7 @@ simulate eventType =
 -- |
 -- | NOTE 2: This function only works for native HTML elements. For emitting
 -- | events on custom React components, use `simulateCustom`.
-simulate' :: forall m r. MonadEffect m => String -> Record r -> ElementWrapper -> m Unit
+simulate' :: forall m r. MonadEffect m => String -> Record r -> Wrapper SingleNode -> m Unit
 simulate' eventType event =
   liftEffect <<< runEffectFn3 simulate_ eventType (unsafeToForeign event)
 
@@ -184,83 +190,81 @@ simulate' eventType event =
 -- | checks whatsoever. This is, of course, not type-safe, but it is in line
 -- | with what the event handler should expect anyway: after all, the underlying
 -- | JavaScript component may pass anything at all as event argument.
-simulateCustom' :: forall m a. MonadEffect m => String -> a -> ElementWrapper -> m Unit
+simulateCustom' :: forall m a. MonadEffect m => String -> a -> Wrapper SingleNode -> m Unit
 simulateCustom' eventType event =
   liftEffect <<< runEffectFn3 simulateCustom_ eventType (unsafeToForeign event)
 
--- | Returns the state of the given `ElementWrapper`.
+-- | Returns the state of the given `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/state.html
 -- | for more info.
-state :: forall m. MonadEffect m => ElementWrapper -> m Foreign
+state :: forall m. MonadEffect m => Wrapper SingleNode -> m Foreign
 state = liftEffect <<< runEffectFn1 state_
 
--- | Returns the text within the given `ElementWrapper`.
+-- | Returns the text within the given `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/text.html
 -- | for more info.
-text :: forall m. MonadEffect m => ElementWrapper -> m String
+text :: forall m. MonadEffect m => Wrapper SingleNode -> m String
 text = liftEffect <<< runEffectFn1 text_
 
--- | Returns tag name of the given `ElementWrapper`.
+-- | Returns tag name of the given `Wrapper`.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/name.html
 -- | for more info.
-name :: forall m. MonadEffect m => ElementWrapper -> m String
+name :: forall m. MonadEffect m => Wrapper SingleNode -> m String
 name = liftEffect <<< runEffectFn1 name_
 
 -- | Returns the number of times a given selector appears within a wrapper.
-count :: forall m. MonadEffect m => String -> ElementWrapper -> m Int
+count :: forall m. MonadEffect m => String -> Wrapper ManyNodes -> m Int
 count selector wrapper = do
   length <$> find selector wrapper
 
 -- | Unmounts a fully mounted component.
 -- | See https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/unmount.html
 -- | for more info.
-unmount :: forall m. MonadEffect m => ElementWrapper -> m Unit
+unmount :: forall m. MonadEffect m => Wrapper SingleNode -> m Unit
 unmount =
   liftEffect <<< runEffectFn1 unmount_
 
--- | Updates the given `ElementWrapper` to reflect the latest state. Call this
+-- | Updates the given `Wrapper` to reflect the latest state. Call this
 -- | function whenever you think there could be an async change of state that
 -- | caused a re-render. For some reason, Enzyme won't pick up the changes
 -- | automatically. See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/update.html for
 -- | more info.
-update :: forall m. MonadEffect m => ElementWrapper -> m Unit
+update :: forall m n. MonadEffect m => Wrapper n -> m Unit
 update = liftEffect <<< runEffectFn1 update_
 
 foreign import configure_ :: EffectFn1 Adapter Unit
 
-foreign import mount_ :: EffectFn1 ReactElement ElementWrapper
+foreign import mount_ :: EffectFn1 ReactElement (Wrapper SingleNode)
 
-foreign import shallow_ :: EffectFn1 ReactElement ElementWrapper
+foreign import shallow_ :: EffectFn1 ReactElement (Wrapper SingleNode)
 
-foreign import at_ :: EffectFn2 Int ElementWrapper ElementWrapper
+foreign import at_ :: EffectFn2 Int (Wrapper ManyNodes) (Wrapper SingleNode)
 
-foreign import debug_ :: EffectFn1 ElementWrapper String
+foreign import debug_ :: forall n. EffectFn1 (Wrapper n) String
 
-foreign import exists_ :: EffectFn2 String ElementWrapper Boolean
+foreign import exists_ :: forall n. EffectFn2 String (Wrapper n) Boolean
 
-foreign import find_ :: EffectFn2 String ElementWrapper ElementWrapper
+foreign import find_ :: forall n. EffectFn2 String (Wrapper n) (Wrapper ManyNodes)
 
-foreign import parent_ :: EffectFn1 ElementWrapper ElementWrapper
+foreign import parent_ :: forall n. EffectFn1 (Wrapper n) (Wrapper n)
 
-foreign import is_ :: EffectFn2 String ElementWrapper Boolean
+foreign import is_ :: EffectFn2 String (Wrapper SingleNode) Boolean
 
-foreign import prop_ :: forall a. EffectFn2 String ElementWrapper a
+foreign import prop_ :: forall a. EffectFn2 String (Wrapper SingleNode) a
 
-foreign import unsafeSetState_ :: forall state. Fn2 state ElementWrapper (EffectFnAff Unit)
+foreign import unsafeSetState_ :: forall state. Fn2 state (Wrapper SingleNode) (EffectFnAff Unit)
 
-foreign import simulate_ :: EffectFn3 String Foreign ElementWrapper Unit
+foreign import simulate_ :: EffectFn3 String Foreign (Wrapper SingleNode) Unit
 
-foreign import simulateCustom_ :: EffectFn3 String Foreign ElementWrapper Unit
+foreign import simulateCustom_ :: EffectFn3 String Foreign (Wrapper SingleNode) Unit
 
-foreign import state_ :: EffectFn1 ElementWrapper Foreign
+foreign import state_ :: EffectFn1 (Wrapper SingleNode) Foreign
 
-foreign import text_ :: EffectFn1 ElementWrapper String
+foreign import text_ :: EffectFn1 (Wrapper SingleNode) String
 
-foreign import name_ :: EffectFn1 ElementWrapper String
+foreign import name_ :: EffectFn1 (Wrapper SingleNode) String
 
-foreign import unmount_ :: EffectFn1 ElementWrapper Unit
+foreign import unmount_ :: EffectFn1 (Wrapper SingleNode) Unit
 
-foreign import update_ :: EffectFn1 ElementWrapper Unit
-
-foreign import data ElementWrapper :: Type
+foreign import update_ :: forall n. EffectFn1 (Wrapper n) Unit

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [ "elmish-html", "spec", "transformers" ]
+  dependencies = conf.dependencies # [ "either", "elmish-html", "spec", "transformers" ]
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -38,7 +38,7 @@ spec = do
     it "crashes when multiple elements are found" $
       testComponent def $
         try (find ".qux p") >>= case _ of
-          Left err -> message err `shouldEqual` "Expected a single element matching '.qux p', but found 2"
+          Left err -> message err `shouldEqual` "Expected a single element matching '.qux p', but found 3"
           Right _ -> fail "Expected find to crash"
     it "crashes when zero elements are found" $
       testComponent def $
@@ -49,7 +49,8 @@ spec = do
   describe "findAll" $
     it "gets multiple elements" $
       testComponent def do
-        findAll ".qux" >> findAll "p" >> length >>= shouldEqual 2
+        findAll ".qux" >> length >>= shouldEqual 2
+        findAll ".qux" >> findAll "p" >> length >>= shouldEqual 3
         findAll ".qux" >> findAll "p" >> at 0 >> text >>= shouldEqual "First"
 
   describe "exists" do
@@ -103,6 +104,9 @@ def =
       , H.div "qux"
         [ H.p "" "First"
         , H.p "" "Second"
+        ]
+      , H.div "qux"
+        [ H.p "" "Third"
         ]
       , if s.bar then
           H.div "bar" "Bar"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,7 @@ import Effect (Effect)
 import Effect.Aff (launchAff_, message, try)
 import Elmish ((<?|))
 import Elmish.Component (ComponentDef)
-import Elmish.Enzyme (at, clickOn, exists, find, findSingle, length, prop, simulate', testComponent, testElement, text, (>>))
+import Elmish.Enzyme (at, clickOn, exists, findAll, find, length, prop, simulate', testComponent, testElement, text, (>>))
 import Elmish.Enzyme as Enzyme
 import Elmish.Enzyme.Adapter as Adapter
 import Elmish.Foreign (readForeign)
@@ -31,26 +31,26 @@ spec = do
       testElement (H.div "" "Foo") $
         text >>= shouldEqual "Foo"
 
-  describe "findSingle" do
+  describe "find" do
     it "gets an element wrapper by a selector" $
       testComponent def $
-        findSingle ".bar" >> text >>= shouldEqual "Bar"
+        find ".bar" >> text >>= shouldEqual "Bar"
     it "crashes when multiple elements are found" $
       testComponent def $
-        try (findSingle ".qux p") >>= case _ of
+        try (find ".qux p") >>= case _ of
           Left err -> message err `shouldEqual` "Expected a single element matching '.qux p', but found 2"
-          Right _ -> fail "Expected findSingle to crash"
+          Right _ -> fail "Expected find to crash"
     it "crashes when zero elements are found" $
       testComponent def $
-        try (findSingle ".qux a") >>= case _ of
+        try (find ".qux a") >>= case _ of
           Left err -> message err `shouldEqual` "Expected a single element matching '.qux a', but found 0"
-          Right _ -> fail "Expected findSingle to crash"
+          Right _ -> fail "Expected find to crash"
 
-  describe "find" $
+  describe "findAll" $
     it "gets multiple elements" $
       testComponent def do
-        find ".qux" >> find "p" >> length >>= shouldEqual 2
-        find ".qux" >> find "p" >> at 0 >> text >>= shouldEqual "First"
+        findAll ".qux" >> findAll "p" >> length >>= shouldEqual 2
+        findAll ".qux" >> findAll "p" >> at 0 >> text >>= shouldEqual "First"
 
   describe "exists" do
     it "returns `true` when selector is found" $
@@ -64,7 +64,7 @@ spec = do
   describe "clickOn" $
     it "simulates a click event on a given selector" $
       testComponent def do
-        findSingle ".bar" >> text >>= shouldEqual "Bar"
+        find ".bar" >> text >>= shouldEqual "Bar"
         clickOn ".toggle-bar"
         exists ".bar" >>= shouldEqual false
 
@@ -76,10 +76,10 @@ spec = do
   describe "simulate'" $
     it "simulates a given event with the given argument on the current wrapper" $
       testComponent def do
-        findSingle ".baz" >> do
+        find ".baz" >> do
           prop "value" >>= shouldEqual ""
           simulate' "change" { target: { value: "New text" } }
-        findSingle ".baz" >> prop "value" >>= shouldEqual "New text"
+        find ".baz" >> prop "value" >>= shouldEqual "New text"
 
 -- Test Component
 


### PR DESCRIPTION
* `ElementWrapper` renamed to `Wrapper` (to reduce noise) and given a type parameter - either `SingleNode` or `ManyNodes`, - effectively creating two separate types `Wrapper SingleNode` and `Wrapper ManyNodes`, but still allowing for polymorphism like `forall n. Wrapper n`
* All functions annotated with either `SingleNode` or `ManyNodes` or polymorphically, according to how they work.
* `EnzymeM` given a type parameter to denote the current context's multiplicity.
* The `find` function is the keystone of the whole scheme. This is where the single/many split happens.
    * The function is broken down into two cases - `findAll` returns `ManyNodes`, while `find` returns `SingleNode`.
    * At first I had the idea of overloading `find`, so that the required multiplicity could be inferred from the surrounding code, e.g. `find "foo" >> length` would mean `find @ManyNodes`, while `find "foo" >> text` would mean `find @SingleNode`. Unfortunately this did not work out, because it created ambiguous type variable in case of two `find` calls in a row, e.g. `find "foo" >> find "bar"`.
* Note that I effectively renamed `findSingle` to `find` and `find` to `findAll`.
    * After integrating this into CV App code, it turned out that the old scheme (with `find` and `findSingle`) resulted in very confusing and hard to read test code. 
    * The drawback is that this moves us away from Enzyme's native naming, which may create some friction, but after careful consideration I concluded this was a price worth paying in this particular case.
    * I also considered using `all` instead of `findAll` (like in Capybara), but that would conflict with the `HeytingAlgebra` functions.
* See https://github.com/collegevine/app/pull/8448 for how it integrates into CV App.
* Next step - friendly error messages. To do this, we'll need to put all functions in type classes and then make two instances of each - one "real one" for the correct multiplicity, and one error-emitting one for the wrong multiplicity. Although I must say, even the standard error messages are not that bad:

![image](https://user-images.githubusercontent.com/4219105/147840119-38a05277-26fc-402b-a602-471169a8661c.png)
