### PR TITLE
Add children and childAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.3
+
+### Added
+
+- Bindings for `children` and `childAt` Enzyme functions.
+- New helper function, `spy`.
+
 ## 0.0.2
 
 ### Changed

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -67,9 +67,11 @@
 -- | from JavaScript, as well as other similar testing libraries, sych as
 -- | Capybara.
 module Elmish.Enzyme
-  ( EnzymeM
-  , testComponent, testElement
+  ( (>>)
+  , EnzymeM
   , at
+  , childAt
+  , children
   , clickOn
   , count
   , debug
@@ -80,22 +82,28 @@ module Elmish.Enzyme
   , is
   , length
   , mapEach
+  , module ForeignExports
   , name
   , parent
   , prop
-  , simulate, simulate', simulateCustom'
+  , simulate
+  , simulate'
+  , simulateCustom'
   , state
+  , testComponent
+  , testElement
   , text
   , toArray
   , trace
   , unsafeSetState
   , update
-  , waitUntil, waitUntil'
-  , waitWhile, waitWhile'
-  , withElement, withElementM
+  , waitUntil
+  , waitUntil'
+  , waitWhile
+  , waitWhile'
+  , withElement
+  , withElementM
   , withSelector
-  , (>>)
-  , module ForeignExports
   ) where
 
 import Prelude
@@ -206,6 +214,12 @@ find selector = do
 -- | info.
 parent :: forall n. EnzymeM n (Wrapper n)
 parent = E.parent =<< ask
+
+children :: forall n. EnzymeM n (Wrapper ManyNodes)
+children = E.children =<< ask
+
+childAt :: forall n. Int -> EnzymeM n (Wrapper SingleNode)
+childAt n = E.childAt n =<< ask
 
 -- | Returns a `Boolean` indicating whether the current element matches
 -- | the given selector.

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -89,6 +89,7 @@ module Elmish.Enzyme
   , simulate
   , simulate'
   , simulateCustom'
+  , spy
   , state
   , testComponent
   , testElement
@@ -177,6 +178,9 @@ debug = E.debug =<< ask
 -- | Logs a string representing the DOM tree of the current element(s).
 trace :: forall n. DebugWarning => EnzymeM n Unit
 trace = log =<< debug
+
+spy :: forall n. DebugWarning => EnzymeM n (Wrapper n)
+spy = ask <* trace
 
 -- | Returns a `Boolean` indicating whether a given selector exists within the
 -- | current element.

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -220,13 +220,16 @@ find selector = do
 parent :: forall n. EnzymeM n (Wrapper n)
 parent = E.parent =<< ask
 
--- | Returns the child nodes of the current `Wrapper`. See
--- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/children.html ffor
+-- | Returns the child nodes of the current `Wrapper`. When the current context
+-- | contains multiple elements, the result will contain the children of each
+-- | element. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/children.html for
 -- | more info.
 children :: forall n. EnzymeM n (Wrapper ManyNodes)
 children = E.children =<< ask
 
--- | Returns the child node at index `idx` of the current `Wrapper`. See
+-- | Returns the child node at index `idx` of the current `Wrapper`.`childAt n`
+-- | is equivalent to `children >> at n` See
 -- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/childAt.html ffor
 -- | more info.
 childAt :: forall n. Int -> EnzymeM n (Wrapper SingleNode)

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -179,6 +179,13 @@ debug = E.debug =<< ask
 trace :: forall n. DebugWarning => EnzymeM n Unit
 trace = log =<< debug
 
+-- | Logs a string representing the DOM tree of the current element(s) and
+-- | returns the original `Wrapper`, so that it can be used in a `withElementM`
+-- | chain, like so:
+-- |
+-- | ```purs
+-- | spy >> find "foo" >> spy >> childAt 0 >> spy >> text >>= shouldEqual "Foo"
+-- | ```
 spy :: forall n. DebugWarning => EnzymeM n (Wrapper n)
 spy = ask <* trace
 
@@ -219,9 +226,15 @@ find selector = do
 parent :: forall n. EnzymeM n (Wrapper n)
 parent = E.parent =<< ask
 
+-- | Returns the child nodes of the current `Wrapper`. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/children.html ffor
+-- | more info.
 children :: forall n. EnzymeM n (Wrapper ManyNodes)
 children = E.children =<< ask
 
+-- | Returns the child node at index `idx` of the current `Wrapper`. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/childAt.html ffor
+-- | more info.
 childAt :: forall n. Int -> EnzymeM n (Wrapper SingleNode)
 childAt n = E.childAt n =<< ask
 

--- a/src/Elmish/Enzyme.purs
+++ b/src/Elmish/Enzyme.purs
@@ -67,8 +67,8 @@
 -- | from JavaScript, as well as other similar testing libraries, sych as
 -- | Capybara.
 module Elmish.Enzyme
-  ( (>>)
-  , EnzymeM
+  ( EnzymeM
+  , testComponent, testElement
   , at
   , childAt
   , children
@@ -82,29 +82,23 @@ module Elmish.Enzyme
   , is
   , length
   , mapEach
-  , module ForeignExports
   , name
   , parent
   , prop
-  , simulate
-  , simulate'
-  , simulateCustom'
+  , simulate, simulate', simulateCustom'
   , spy
   , state
-  , testComponent
-  , testElement
   , text
   , toArray
   , trace
   , unsafeSetState
   , update
-  , waitUntil
-  , waitUntil'
-  , waitWhile
-  , waitWhile'
-  , withElement
-  , withElementM
+  , waitUntil, waitUntil'
+  , waitWhile, waitWhile'
+  , withElement, withElementM
   , withSelector
+  , (>>)
+  , module ForeignExports
   ) where
 
 import Prelude

--- a/src/Elmish/Enzyme/Foreign.js
+++ b/src/Elmish/Enzyme/Foreign.js
@@ -16,6 +16,10 @@ exports.find_ = (selector, wrapper) => wrapper.find(selector)
 
 exports.parent_ = wrapper => wrapper.parent()
 
+exports.children_ = wrapper => wrapper.children()
+
+exports.childAt_ = (idx, wrapper) => wrapper.childAt(idx)
+
 exports.is_ = (selector, wrapper) => wrapper.is(selector)
 
 exports.length = wrapper => wrapper.length

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -3,10 +3,9 @@
 -- | wrapper around Enzyme with a few convenience functions added. For a
 -- | convenient API, use `Elmish.Enzyme` instead.
 module Elmish.Enzyme.Foreign
-  ( ManyNodes
-  , NodeMultiplicity
-  , SingleNode
-  , Wrapper
+  ( Wrapper, NodeMultiplicity, SingleNode, ManyNodes
+  , mount
+  , mountComponent
   , at
   , childAt
   , children
@@ -18,8 +17,6 @@ module Elmish.Enzyme.Foreign
   , forEach
   , is
   , length
-  , mount
-  , mountComponent
   , name
   , parent
   , prop

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -117,9 +117,15 @@ find selector w = liftEffect $ runEffectFn2 find_ selector w
 parent :: forall m n. MonadEffect m => Wrapper n -> m (Wrapper n)
 parent w = liftEffect $ runEffectFn1 parent_ w
 
+-- | Returns the child nodes of the given `Wrapper`. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/children.html ffor
+-- | more info.
 children :: forall m n. MonadEffect m => Wrapper n -> m (Wrapper ManyNodes)
 children w = liftEffect $ runEffectFn1 children_ w
 
+-- | Returns the child node at index `idx` of the given `Wrapper`. See
+-- | https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/childAt.html ffor
+-- | more info.
 childAt :: forall m n. MonadEffect m => Int -> Wrapper n -> m (Wrapper SingleNode)
 childAt idx w = liftEffect $ runEffectFn2 childAt_ idx w
 

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -4,12 +4,12 @@
 -- | convenient API, use `Elmish.Enzyme` instead.
 module Elmish.Enzyme.Foreign
   ( Wrapper, NodeMultiplicity, SingleNode, ManyNodes
+  , configure
   , mount
   , mountComponent
   , at
   , childAt
   , children
-  , configure
   , count
   , debug
   , exists

--- a/src/Elmish/Enzyme/Foreign.purs
+++ b/src/Elmish/Enzyme/Foreign.purs
@@ -3,18 +3,23 @@
 -- | wrapper around Enzyme with a few convenience functions added. For a
 -- | convenient API, use `Elmish.Enzyme` instead.
 module Elmish.Enzyme.Foreign
-  ( Wrapper, NodeMultiplicity, SingleNode, ManyNodes
+  ( ManyNodes
+  , NodeMultiplicity
+  , SingleNode
+  , Wrapper
+  , at
+  , childAt
+  , children
   , configure
   , count
-  , mount
-  , mountComponent
-  , at
   , debug
   , exists
   , find
   , forEach
   , is
   , length
+  , mount
+  , mountComponent
   , name
   , parent
   , prop
@@ -111,6 +116,12 @@ find selector w = liftEffect $ runEffectFn2 find_ selector w
 -- | more info.
 parent :: forall m n. MonadEffect m => Wrapper n -> m (Wrapper n)
 parent w = liftEffect $ runEffectFn1 parent_ w
+
+children :: forall m n. MonadEffect m => Wrapper n -> m (Wrapper ManyNodes)
+children w = liftEffect $ runEffectFn1 children_ w
+
+childAt :: forall m n. MonadEffect m => Int -> Wrapper n -> m (Wrapper SingleNode)
+childAt idx w = liftEffect $ runEffectFn2 childAt_ idx w
 
 -- | Returns a `Boolean` indicating whether the given `Wrapper` matches
 -- | the given selector.
@@ -224,6 +235,10 @@ foreign import exists_ :: forall n. EffectFn2 String (Wrapper n) Boolean
 foreign import find_ :: forall n. EffectFn2 String (Wrapper n) (Wrapper ManyNodes)
 
 foreign import parent_ :: forall n. EffectFn1 (Wrapper n) (Wrapper n)
+
+foreign import children_ :: forall n. EffectFn1 (Wrapper n) (Wrapper ManyNodes)
+
+foreign import childAt_ :: forall n. EffectFn2 Int (Wrapper n) (Wrapper SingleNode)
 
 foreign import is_ :: EffectFn2 String (Wrapper SingleNode) Boolean
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,7 @@ import Effect (Effect)
 import Effect.Aff (launchAff_, message, try)
 import Elmish ((<?|))
 import Elmish.Component (ComponentDef)
-import Elmish.Enzyme (at, clickOn, exists, findAll, find, length, prop, simulate', testComponent, testElement, text, (>>))
+import Elmish.Enzyme (at, children, clickOn, exists, find, findAll, length, mapEach, prop, simulate', testComponent, testElement, text, (>>))
 import Elmish.Enzyme as Enzyme
 import Elmish.Enzyme.Adapter as Adapter
 import Elmish.Foreign (readForeign)
@@ -81,6 +81,26 @@ spec = do
           prop "value" >>= shouldEqual ""
           simulate' "change" { target: { value: "New text" } }
         find ".baz" >> prop "value" >>= shouldEqual "New text"
+
+  describe "children" do
+    let
+      elem =
+        H.div ""
+        [ H.div_ "" { id: "foo" } H.empty
+        , H.div_ "" { id: "bar" } $ H.div_ "" { id: "bar-child" } H.empty
+        , H.div_ "" { id: "baz" }
+          [ H.div_ "" { id: "baz-child-1" } H.empty
+          , H.div_ "" { id: "baz-child-2" } H.empty
+          ]
+        ]
+
+    it "returns a wrapper containing the child nodes" $
+      testElement elem $
+        children >> mapEach (prop "id") >>= shouldEqual ["foo", "bar", "baz"]
+
+    it "returns children of each node when called on many nodes" $
+      testElement elem $
+        children >> children >> mapEach (prop "id") >>= shouldEqual ["bar-child", "baz-child-1", "baz-child-2"]
 
 -- Test Component
 


### PR DESCRIPTION
Adds bindings for `children` and `childAt` as well as a new debug helper, `spy`.